### PR TITLE
mDNS service type is _nitroshare._tcp.local.

### DIFF
--- a/app/src/main/java/net/nitroshare/android/discovery/Device.java
+++ b/app/src/main/java/net/nitroshare/android/discovery/Device.java
@@ -12,7 +12,7 @@ import java.net.InetAddress;
  */
 public class Device implements Serializable {
 
-    public static final String SERVICE_TYPE = "_nitroshare._tcp.";
+    public static final String SERVICE_TYPE = "_nitroshare._tcp.local.";
 
     public static final String UUID = "uuid";
 


### PR DESCRIPTION
I noticed that Desktop client sends `_nitroshare._tcp.local.` while Android version doesn't seem to send anything. Perhaps this can help.