### PR TITLE
Send URL

### DIFF
--- a/app/src/main/java/net/nitroshare/android/bundle/UrlItem.java
+++ b/app/src/main/java/net/nitroshare/android/bundle/UrlItem.java
@@ -15,7 +15,6 @@ import java.util.Map;
 public class UrlItem extends Item {
 
     public static final String TYPE_NAME = "url";
-
     private Map<String, Object> mProperties;
 
     /**
@@ -32,8 +31,9 @@ public class UrlItem extends Item {
     public UrlItem(Uri uri) {
         mProperties = new HashMap<>();
         mProperties.put(TYPE, TYPE_NAME);
+        mProperties.put(TYPE_NAME, uri.toString());
         mProperties.put(NAME, uri.toString());
-        mProperties.put(SIZE, 0);
+        mProperties.put(SIZE, "0");
     }
 
     /**

--- a/app/src/main/java/net/nitroshare/android/transfer/TransferService.java
+++ b/app/src/main/java/net/nitroshare/android/transfer/TransferService.java
@@ -15,6 +15,7 @@ import android.util.Log;
 
 import net.nitroshare.android.bundle.Bundle;
 import net.nitroshare.android.bundle.FileItem;
+import net.nitroshare.android.bundle.UrlItem;
 import net.nitroshare.android.discovery.Device;
 import net.nitroshare.android.util.Settings;
 
@@ -204,6 +205,9 @@ public class TransferService extends Service {
                     } else {
                         bundle.addItem(new FileItem(file));
                     }
+                    break;
+                default:
+                    bundle.addItem(new UrlItem(uri));
                     break;
             }
         }

--- a/app/src/main/java/net/nitroshare/android/ui/ShareActivity.java
+++ b/app/src/main/java/net/nitroshare/android/ui/ShareActivity.java
@@ -216,8 +216,7 @@ public class ShareActivity extends AppCompatActivity {
      */
     private boolean isValidIntent() {
         return (getIntent().getAction().equals(Intent.ACTION_SEND_MULTIPLE) ||
-                getIntent().getAction().equals(Intent.ACTION_SEND)) &&
-                getIntent().hasExtra(Intent.EXTRA_STREAM);
+                getIntent().getAction().equals(Intent.ACTION_SEND));
     }
 
     /**
@@ -228,8 +227,13 @@ public class ShareActivity extends AppCompatActivity {
         if (getIntent().getAction().equals(Intent.ACTION_SEND_MULTIPLE)) {
             return getIntent().getParcelableArrayListExtra(Intent.EXTRA_STREAM);
         } else {
+
             ArrayList<Uri> uriList = new ArrayList<>();
-            uriList.add((Uri) getIntent().getParcelableExtra(Intent.EXTRA_STREAM));
+            if (getIntent().hasExtra(Intent.EXTRA_STREAM)) {
+                uriList.add((Uri) getIntent().getParcelableExtra(Intent.EXTRA_STREAM));
+            } else if (getIntent().hasExtra(Intent.EXTRA_TEXT)) {
+                uriList.add(android.net.Uri.parse(getIntent().getStringExtra(Intent.EXTRA_TEXT)));
+            }
             return uriList;
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -3,13 +3,10 @@
 buildscript {
     repositories {
         jcenter()
-        maven { url 'https://maven.google.com' }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath 'com.android.tools.build:gradle:3.6.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
I added the ability to send a URL. 

I still have the following concerns:

1. Any URI will be sent to the remote peer, it has security issues with opening something without asking the user. At least the device has to be verified before opening any link.
2. `android.net.Uri.parse` is called later, not in the `isValidIntent`, so, for now, the user will not see the message that the NitroShare is not able to share this type of content.
